### PR TITLE
DSE-28618

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -27,10 +27,9 @@ feature_dependencies:
 
 runtimes:
   - editor: Workbench
-    kernel: Python 3.7
+    kernel: Python 3.9
     edition: Standard
-    version: 2021.12
-    addons: ["Spark 2.4.8 - CDE 1.15 - HOTFIX-1"]
+    addons: ["Spark 3.2.3 - CDE 1.19.2 - HOTFIX-2"]
 
 tasks:
   - type: run_session

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 git+https://github.com/fastforwardlabs/cmlbootstrap#egg=cmlbootstrap
 dill==0.3.1.1
 lime==0.1.1.36 
-scikit-learn==0.21.3
 Cython==0.29.28
+scikit-learn==0.21.3
 xlrd==1.2.0
 pandas==1.1.5
 numpy==1.19.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ git+https://github.com/fastforwardlabs/cmlbootstrap#egg=cmlbootstrap
 dill==0.3.1.1
 lime==0.1.1.36 
 Cython==0.29.28
-scikit-learn==0.21.3
 xlrd==1.2.0
 pandas==1.1.5
 numpy==1.19.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/fastforwardlabs/cmlbootstrap#egg=cmlbootstrap
 dill==0.3.1.1
 lime==0.1.1.36 
-Cython==0.29.28
+scikit-learn==0.21.3 
 xlrd==1.2.0
 pandas==1.1.5
 numpy==1.19.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 git+https://github.com/fastforwardlabs/cmlbootstrap#egg=cmlbootstrap
 dill==0.3.1.1
 lime==0.1.1.36 
-scikit-learn==0.21.3 
+scikit-learn==0.21.3
+Cython==0.29.28
 xlrd==1.2.0
 pandas==1.1.5
 numpy==1.19.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/fastforwardlabs/cmlbootstrap#egg=cmlbootstrap
 dill==0.3.1.1
 lime==0.1.1.36 
-scikit-learn==0.21.3 
+scikit-learn==1.0.2 
 xlrd==1.2.0
 pandas==1.1.5
 numpy==1.19.5


### PR DESCRIPTION
Update CML AMP Churn Prediction to latest Runtime version and Python 3.9 edition, and Spark 3
Also had to upgrade scikit-learn package version to 1.0.2